### PR TITLE
Removed return type declaration

### DIFF
--- a/engine/Shopware/Controllers/Frontend/Listing.php
+++ b/engine/Shopware/Controllers/Frontend/Listing.php
@@ -331,9 +331,9 @@ class Shopware_Controllers_Frontend_Listing extends Enlight_Controller_Action
     /**
      * @param array<string, mixed> $categoryContent
      *
-     * @return array{controller?: string, sArticle?: int}
+     * @return string|array{controller?: string, sArticle?: int}
      */
-    private function getRedirectLocation(array $categoryContent, bool $hasEmotion, ShopContextInterface $context): array
+    private function getRedirectLocation(array $categoryContent, bool $hasEmotion, ShopContextInterface $context)
     {
         $location = [];
 


### PR DESCRIPTION
### 1. Why is this change necessary?
In case of a category has an external link, the method "getRedirectLocation" will return a string. So the return type declaration of this method is wrong and the shop will crash.

### 2. What does this change do, exactly?
It removes the return type declaration for still supporting PHP 7.4.

### 3. Describe each step to reproduce the issue or behaviour.
Add an external link to a category and call it in the frontend. The shop will crash.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.